### PR TITLE
Fix backend requirements

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,5 +15,4 @@ python-multipart
 httpx
 
 # Additional utilities
-python-dateutily
-lightrag
+python-dateutil


### PR DESCRIPTION
## Summary
- correct the python-dateutil dependency name
- remove the duplicate lightrag entry

## Testing
- `python -m pip check`
- `python -m pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement lightrag)*

------
https://chatgpt.com/codex/tasks/task_e_6840872f0a108329b3a000d7e3a23465