### PR TITLE
Add brainstorming and writing routers

### DIFF
--- a/backend/api/brainstorm.py
+++ b/backend/api/brainstorm.py
@@ -1,0 +1,48 @@
+"""
+Brainstorm API - Exposes BrainstormModule endpoints
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+import sys
+import os
+
+# Ensure backend modules can be imported when running as package or script
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.models import BrainstormRequest, BrainstormResponse, BrainstormSummary
+from core.project_manager import project_manager
+from core.lightrag_client import lightrag_manager
+from core.brainstorm import BrainstormModule, get_brainstorm_module
+
+router = APIRouter(prefix="/projects/{project_id}/brainstorm", tags=["brainstorm"])
+
+
+def _get_module() -> BrainstormModule:
+    """Instantiate or retrieve the BrainstormModule"""
+    return get_brainstorm_module(project_manager, lightrag_manager)
+
+
+@router.post("/", response_model=BrainstormResponse)
+async def generate_brainstorm(
+    project_id: str,
+    request: BrainstormRequest,
+    module: BrainstormModule = Depends(_get_module),
+):
+    """Generate brainstorm content for a project"""
+    try:
+        request.project_id = project_id
+        return await module.generate_brainstorm(request)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/history", response_model=BrainstormSummary)
+async def brainstorm_history(
+    project_id: str,
+    module: BrainstormModule = Depends(_get_module),
+):
+    """Get brainstorm history for a project"""
+    try:
+        return await module.get_brainstorm_history(project_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/api/write.py
+++ b/backend/api/write.py
@@ -1,0 +1,48 @@
+"""
+Write API - Exposes WriteModule endpoints
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.models import WriteRequest, WriteResponse, WriteSummary
+from core.project_manager import project_manager
+from core.lightrag_client import lightrag_manager
+from core.brainstorm import get_brainstorm_module
+from core.write import WriteModule, get_write_module
+
+router = APIRouter(prefix="/projects/{project_id}/write", tags=["write"])
+
+
+def _get_module() -> WriteModule:
+    brainstorm = get_brainstorm_module(project_manager, lightrag_manager)
+    return get_write_module(project_manager, lightrag_manager, brainstorm)
+
+
+@router.post("/", response_model=WriteResponse)
+async def generate_write(
+    project_id: str,
+    request: WriteRequest,
+    module: WriteModule = Depends(_get_module),
+):
+    """Generate written content for a project"""
+    try:
+        request.project_id = project_id
+        return await module.generate_write(request)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/history", response_model=WriteSummary)
+async def write_history(
+    project_id: str,
+    module: WriteModule = Depends(_get_module),
+):
+    """Get write history for a project"""
+    try:
+        return await module.get_write_history(project_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,9 +33,13 @@ def health_check():
 # Include API routers
 from api.projects import router as projects_router
 from api.buckets import router as buckets_router
+from api.brainstorm import router as brainstorm_router
+from api.write import router as write_router
 
 app.include_router(projects_router)
 app.include_router(buckets_router)
+app.include_router(brainstorm_router)
+app.include_router(write_router)
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
## Summary
- add FastAPI router for brainstorm endpoints
- add FastAPI router for write endpoints
- wire new routers into the backend app

## Testing
- `python -m py_compile backend/api/brainstorm.py backend/api/write.py backend/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ad592fb4832991d873151195fccf