### PR TITLE
Update LightRAG manager imports

### DIFF
--- a/backend/core/brainstorm.py
+++ b/backend/core/brainstorm.py
@@ -13,7 +13,7 @@ from .models import (
     BrainstormRequest, BrainstormResponse, BrainstormSummary
 )
 from .project_manager import ProjectManager
-from .lightrag_client import BucketManager
+from .lightrag_manager import LightRAGManager
 
 # =============================================================================
 # BRAINSTORM MODULE CLASS
@@ -25,7 +25,7 @@ class BrainstormModule:
     Direct port of your brainstorm.py workflow
     """
     
-    def __init__(self, project_manager: ProjectManager, bucket_manager: BucketManager):
+    def __init__(self, project_manager: ProjectManager, bucket_manager: LightRAGManager):
         self.project_manager = project_manager
         self.bucket_manager = bucket_manager
         
@@ -380,7 +380,7 @@ class BrainstormModule:
 # This will be injected with dependencies in the API layer
 brainstorm_module = None
 
-def get_brainstorm_module(project_manager: ProjectManager, bucket_manager: BucketManager) -> BrainstormModule:
+def get_brainstorm_module(project_manager: ProjectManager, bucket_manager: LightRAGManager) -> BrainstormModule:
     """Dependency injection for brainstorm module"""
     global brainstorm_module
     if brainstorm_module is None:

--- a/backend/core/write.py
+++ b/backend/core/write.py
@@ -13,7 +13,7 @@ from .models import (
     WriteRequest, WriteResponse, WriteEdit, WriteSummary
 )
 from .project_manager import ProjectManager
-from .lightrag_client import BucketManager
+from .lightrag_manager import LightRAGManager
 from .brainstorm import BrainstormModule
 
 # =============================================================================
@@ -29,7 +29,7 @@ class WriteModule:
     def __init__(
         self, 
         project_manager: ProjectManager, 
-        bucket_manager: BucketManager,
+        bucket_manager: LightRAGManager,
         brainstorm_module: BrainstormModule
     ):
         self.project_manager = project_manager
@@ -503,7 +503,7 @@ write_module = None
 
 def get_write_module(
     project_manager: ProjectManager, 
-    bucket_manager: BucketManager,
+    bucket_manager: LightRAGManager,
     brainstorm_module: BrainstormModule
 ) -> WriteModule:
     """Dependency injection for write module"""


### PR DESCRIPTION
## Summary
- import `LightRAGManager` instead of a placeholder `BucketManager`
- update constructor type hints in `brainstorm` and `write` modules

## Testing
- `python -m py_compile backend/core/brainstorm.py backend/core/write.py backend/core/lightrag_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ad537ae8832996597c5f1f0b2a6a