### PR TITLE
Refactor modules for new LightRAG manager

### DIFF
--- a/backend/core/brainstorm.py
+++ b/backend/core/brainstorm.py
@@ -13,7 +13,7 @@ from .models import (
     BrainstormRequest, BrainstormResponse, BrainstormSummary
 )
 from .project_manager import ProjectManager
-from .lightrag_manager import BucketManager
+from .lightrag_manager import LightRAGManager
 
 # =============================================================================
 # BRAINSTORM MODULE CLASS
@@ -25,7 +25,7 @@ class BrainstormModule:
     Direct port of your brainstorm.py workflow
     """
     
-    def __init__(self, project_manager: ProjectManager, bucket_manager: BucketManager):
+    def __init__(self, project_manager: ProjectManager, bucket_manager: LightRAGManager):
         self.project_manager = project_manager
         self.bucket_manager = bucket_manager
         
@@ -161,7 +161,8 @@ class BrainstormModule:
         # Get bucket guidance
         bucket_guidance = []
         for bucket_name in selected_buckets:
-            guidance = await self.bucket_manager.get_client(request.project_id).get_bucket_guidance(bucket_name)
+            bucket_info = await self.bucket_manager.get_bucket(request.project_id, bucket_name)
+            guidance = bucket_info.guidance if bucket_info else None
             if guidance:
                 bucket_guidance.append(f"{bucket_name}: {guidance}")
         
@@ -380,7 +381,7 @@ class BrainstormModule:
 # This will be injected with dependencies in the API layer
 brainstorm_module = None
 
-def get_brainstorm_module(project_manager: ProjectManager, bucket_manager: BucketManager) -> BrainstormModule:
+def get_brainstorm_module(project_manager: ProjectManager, bucket_manager: LightRAGManager) -> BrainstormModule:
     """Dependency injection for brainstorm module"""
     global brainstorm_module
     if brainstorm_module is None:

--- a/backend/core/write.py
+++ b/backend/core/write.py
@@ -13,7 +13,7 @@ from .models import (
     WriteRequest, WriteResponse, WriteEdit, WriteSummary
 )
 from .project_manager import ProjectManager
-from .lightrag_manager import BucketManager
+from .lightrag_manager import LightRAGManager
 from .brainstorm import BrainstormModule
 
 # =============================================================================
@@ -28,8 +28,8 @@ class WriteModule:
     
     def __init__(
         self, 
-        project_manager: ProjectManager, 
-        bucket_manager: BucketManager,
+        project_manager: ProjectManager,
+        bucket_manager: LightRAGManager,
         brainstorm_module: BrainstormModule
     ):
         self.project_manager = project_manager
@@ -278,9 +278,7 @@ class WriteModule:
         Like your final content generation in write.py
         """
         try:
-            # Use bucket manager's LLM integration for generation
-            # This leverages the same LightRAG LLM setup used for bucket queries
-            client = self.bucket_manager.get_client(project_id)
+            # Use LightRAG's LLM integration for generation
             
             # For now, we'll use a simple approach - in a full implementation,
             # you'd want to integrate with your preferred LLM API directly
@@ -502,8 +500,8 @@ Please revise the original content according to the edit instructions while main
 write_module = None
 
 def get_write_module(
-    project_manager: ProjectManager, 
-    bucket_manager: BucketManager,
+    project_manager: ProjectManager,
+    bucket_manager: LightRAGManager,
     brainstorm_module: BrainstormModule
 ) -> WriteModule:
     """Dependency injection for write module"""


### PR DESCRIPTION
## Summary
- switch brainstorm and write modules to use `LightRAGManager`
- add helper methods to `LightRAGManager`
- drop unused client call in write module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b256ff68832980b994fba7db377d