### PR TITLE
Fix imports to use unified LightRAGManager

### DIFF
--- a/backend/api/brainstorm.py
+++ b/backend/api/brainstorm.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core.models import BrainstormRequest, BrainstormResponse, BrainstormSummary
 from core.project_manager import project_manager
-from core.lightrag_client import lightrag_manager
+from core.lightrag_manager import lightrag_manager
 from core.brainstorm import BrainstormModule, get_brainstorm_module
 
 router = APIRouter(prefix="/projects/{project_id}/brainstorm", tags=["brainstorm"])

--- a/backend/api/write.py
+++ b/backend/api/write.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from core.models import WriteRequest, WriteResponse, WriteSummary
 from core.project_manager import project_manager
-from core.lightrag_client import lightrag_manager
+from core.lightrag_manager import lightrag_manager
 from core.brainstorm import get_brainstorm_module
 from core.write import WriteModule, get_write_module
 


### PR DESCRIPTION
## Summary
- update API modules to import `lightrag_manager` from consolidated manager

## Testing
- `pytest backend/core`

------
https://chatgpt.com/codex/tasks/task_e_6840b257d72483299e71f6877c4102a1